### PR TITLE
Enhance logging and adjust labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@
 ## 輸出檔案
 - `output/TSE_stock_records_20250407_20250604.txt`
 - `output/TSE_stock_price_comparison_20250526_20250604.txt`
+- `output/stock_price_analyzer.log`
 
 以上檔案儲存在本儲存庫的 `output/` 目錄下，方便在雲端或不同環境使用。
+程式執行過程會寫入 `stock_price_analyzer.log` 以便追蹤下載與比對狀態。
 
 ## 執行方式
 ```bash
@@ -36,5 +38,5 @@ python stock_price_analyzer.py
 
 程式會輸出範例格式：
 ```
-1101,台泥,2025-06-02創新低,收盤價27.70,(4月低點:28.50),新低價25.50
+1101,台泥,2025-06-02創新低,收盤價27.70,(基準低點:28.50),新低價25.50
 ```


### PR DESCRIPTION
## Summary
- add a simple logging setup that records downloads and output generation
- label baseline prices generically instead of "4月低點"
- document the log file in README

## Testing
- `python -m py_compile stock_price_analyzer.py`
- `python stock_price_analyzer.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68408d8ed03c833395c56dfbdfa92e17